### PR TITLE
Goon scope creep

### DIFF
--- a/Injuries/Localization/English/Grit and Glory.loca.xml
+++ b/Injuries/Localization/English/Grit and Glory.loca.xml
@@ -43,4 +43,5 @@ The condition heals if you succeed a &lt;LSTag Tooltip="Constitution"&gt;Constit
 	<content contentuid="h5cf11ad0g3feag4ff6g8a90g1fe14c00a5fe" version="1">Systematic Damage</content> -- Cold damage
 	<content contentuid="h5d84c3d1g8f32g45e4g8ca0g3587fdad6755" version="1">You have disadvantage on &lt;LSTag Tooltip="Strength"&gt;Strength&lt;/LSTag&gt;, &lt;LSTag Tooltip="Dexterity"&gt;Dexterity&lt;/LSTag&gt;, and &lt;LSTag Tooltip="Constitution"&gt;Constitution&lt;/LSTag&gt; &lt;LSTag Tooltip="AbilityCheck"&gt;Ability Checks&lt;/LSTag&gt; and &lt;LSTag Tooltip="SavingThrow"&gt;Saving Throws&lt;/LSTag&gt;.
 Magic such as the &lt;LSTag Type="Spell" Tooltip="Target_Regenerate"&gt;Regenerate&lt;/LSTag&gt; spell can cure the damage.</content> -- You have disadvantage on Strength, Dexterity, and Constitution ability checks and Strength, Dexterity, and Constitution saving throws. Magic such as the regenerate spell cures this damage.
+    <content contentuid="h1b6a9749a6eb4488ad5cf03f67eb45f6494b" version="1"></content>
 </contentList>

--- a/Injuries/Localization/English/Grit and Glory.loca.xml
+++ b/Injuries/Localization/English/Grit and Glory.loca.xml
@@ -43,5 +43,4 @@ The condition heals if you succeed a &lt;LSTag Tooltip="Constitution"&gt;Constit
 	<content contentuid="h5cf11ad0g3feag4ff6g8a90g1fe14c00a5fe" version="1">Systematic Damage</content> -- Cold damage
 	<content contentuid="h5d84c3d1g8f32g45e4g8ca0g3587fdad6755" version="1">You have disadvantage on &lt;LSTag Tooltip="Strength"&gt;Strength&lt;/LSTag&gt;, &lt;LSTag Tooltip="Dexterity"&gt;Dexterity&lt;/LSTag&gt;, and &lt;LSTag Tooltip="Constitution"&gt;Constitution&lt;/LSTag&gt; &lt;LSTag Tooltip="AbilityCheck"&gt;Ability Checks&lt;/LSTag&gt; and &lt;LSTag Tooltip="SavingThrow"&gt;Saving Throws&lt;/LSTag&gt;.
 Magic such as the &lt;LSTag Type="Spell" Tooltip="Target_Regenerate"&gt;Regenerate&lt;/LSTag&gt; spell can cure the damage.</content> -- You have disadvantage on Strength, Dexterity, and Constitution ability checks and Strength, Dexterity, and Constitution saving throws. Magic such as the regenerate spell cures this damage.
-    <content contentuid="h1b6a9749a6eb4488ad5cf03f67eb45f6494b" version="1"></content>
 </contentList>

--- a/Injuries/Localization/English/Injuries.loca.xml
+++ b/Injuries/Localization/English/Injuries.loca.xml
@@ -53,4 +53,5 @@ Completing a &lt;LSTag Tooltip="ShortRest"&gt;Short Rest&lt;/LSTag&gt; will remo
 	<content contentuid="h5550c488gad91g45ebgbf6dg218c7c4468b7" version="1">Fried Synapses</content>
 	<content contentuid="h6bd6ff42gaf6dg44a9gbdb9g85b6006f0a49" version="1">The abundance of electrical activity in your brain leaves you with &lt;LSTag Tooltip="Disadvantage"&gt;Disadvantage&lt;/LSTag&gt; on &lt;LSTag Tooltip="Intelligence"&gt;Intelligence&lt;/LSTag&gt; &lt;LSTag Tooltip="AbilityCheck"&gt;Ability Checks&lt;/LSTag&gt;.
 Completing a &lt;LSTag Tooltip="ShortRest"&gt;Short Rest&lt;/LSTag&gt; will remove a random injury and completing a &lt;LSTag Tooltip="LongRest"&gt;Long Rest&lt;/LSTag&gt; will remove all injuries.</content>
+    <content contentuid="h1b6a9749a6eb4488ad5cf03f67eb45f6494b" version="1"></content>
 </contentList>

--- a/Injuries/Localization/English/Injuries.loca.xml
+++ b/Injuries/Localization/English/Injuries.loca.xml
@@ -53,5 +53,4 @@ Completing a &lt;LSTag Tooltip="ShortRest"&gt;Short Rest&lt;/LSTag&gt; will remo
 	<content contentuid="h5550c488gad91g45ebgbf6dg218c7c4468b7" version="1">Fried Synapses</content>
 	<content contentuid="h6bd6ff42gaf6dg44a9gbdb9g85b6006f0a49" version="1">The abundance of electrical activity in your brain leaves you with &lt;LSTag Tooltip="Disadvantage"&gt;Disadvantage&lt;/LSTag&gt; on &lt;LSTag Tooltip="Intelligence"&gt;Intelligence&lt;/LSTag&gt; &lt;LSTag Tooltip="AbilityCheck"&gt;Ability Checks&lt;/LSTag&gt;.
 Completing a &lt;LSTag Tooltip="ShortRest"&gt;Short Rest&lt;/LSTag&gt; will remove a random injury and completing a &lt;LSTag Tooltip="LongRest"&gt;Long Rest&lt;/LSTag&gt; will remove all injuries.</content>
-    <content contentuid="h1b6a9749a6eb4488ad5cf03f67eb45f6494b" version="1"></content>
 </contentList>

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Client/Injuries/InjuryMenu.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Client/Injuries/InjuryMenu.lua
@@ -343,7 +343,7 @@ Mods.BG3MCM.IMGUIAPI:InsertModMenuTab(ModuleUUID, "Injuries",
 				headerRow:AddCell():AddText("Actions")
 
 				for displayName, injuryName in TableUtils:OrderedPairs(injuryNameTable, function(injuryDisplayName)
-					return cachedStats[injuryDisplayName].StackPriority
+					return cachedStats[injuryDisplayName].StackPriority .. injuryDisplayName
 				end) do
 					if not InjuryMenu.ConfigurationSlice.injury_specific[injuryName] then
 						InjuryMenu.ConfigurationSlice.injury_specific[injuryName] = TableUtils:DeeplyCopyTable(ConfigurationStructure.DynamicClassDefinitions.injury_class)

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Client/Injuries/InjuryMenu.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Client/Injuries/InjuryMenu.lua
@@ -331,7 +331,7 @@ Mods.BG3MCM.IMGUIAPI:InsertModMenuTab(ModuleUUID, "Injuries",
 
 			local function buildTable(tableCategory, injuryNameTable)
 				systemHeader:AddText(tableCategory).Font = "Large"
-				local injuryTable = systemHeader:AddTable(system .. "_InjuryTable", 4)
+				local injuryTable = systemHeader:AddTable(system .. "_InjuryTable", 5)
 				injuryTable.BordersInnerH = true
 				injuryTable.SizingStretchProp = true
 				injuryTable.PreciseWidths = true
@@ -360,6 +360,7 @@ Mods.BG3MCM.IMGUIAPI:InsertModMenuTab(ModuleUUID, "Injuries",
 
 					local severityCombo = newRow:AddCell():AddCombo("")
 					severityCombo.Options = {
+						"Exclude",
 						"Low",
 						"Medium",
 						"High"

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Client/Injuries/InjuryMenu.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Client/Injuries/InjuryMenu.lua
@@ -406,14 +406,12 @@ Mods.BG3MCM.IMGUIAPI:InsertModMenuTab(ModuleUUID, "Injuries",
 					local injuryPopup
 					customizeButton.OnClick = function()
 						injuryPopup = Ext.IMGUI.NewWindow("Customizing " .. displayName)
-						injuryPopup.TextWrapPos = 0
 						injuryPopup.Closeable = true
 						injuryPopup.OnClose = function()
 							statCountTooltip:OnHoverEnter()
 						end
 
 						local newTabBar = injuryPopup:AddTabBar("InjuryTabBar")
-						newTabBar.TextWrapPos = 0
 						for _, tabGenerator in pairs(InjuryMenu.Tabs.Generators) do
 							local success, error = pcall(function()
 								tabGenerator(newTabBar, injuryName)
@@ -447,9 +445,10 @@ Mods.BG3MCM.IMGUIAPI:InsertModMenuTab(ModuleUUID, "Injuries",
 
 					copyButton.OnClick = function()
 						local copyPopup = Ext.IMGUI.NewWindow("Copying Injury Configs")
+						copyPopup.AlwaysAutoResize = true
 						copyPopup.Closeable = true
 
-						copyPopup:AddText("Copying from: " .. displayName)
+						copyPopup:AddText("Copying from: " .. displayName).Font = "Large"
 						copyPopup:AddText("Close any Customizing windows you have open - they'll show stale data after this runs").TextWrapPos = 0
 						copyPopup:AddNewLine()
 

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Client/Injuries/InjuryReport.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Client/Injuries/InjuryReport.lua
@@ -214,7 +214,12 @@ local function BuildReport()
 					keepGroup = true
 					sepText = sepText .. " || Applied Due To " .. injuryReport["injuryAppliedReason"][injury]
 				end
-				injuryReportGroup:AddSeparatorText(sepText)
+				injuryReportGroup:AddSeparatorText(sepText).Font = "Large"
+
+				if injuryReport["numberOfApplicationsAttempted"] and injuryReport["numberOfApplicationsAttempted"][injury] then
+					injuryReportGroup:AddText(string.format("Application Chance: %s%%", injuryConfig.chance_of_application or 100))
+					injuryReportGroup:AddText(string.format(" | Number Of Attempted Applications: %s", injuryReport["numberOfApplicationsAttempted"][injury])).SameLine = true
+				end
 
 				--#region Damage Report
 				if next(injuryConfig.damage["damage_types"]) then

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Client/Injuries/Tabs/ApplyOnStatusTab.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Client/Injuries/Tabs/ApplyOnStatusTab.lua
@@ -48,6 +48,7 @@ InjuryMenu:RegisterTab(function(tabBar, injury)
 	end
 	local applyOnConfig = InjuryMenu.ConfigurationSlice.injury_specific[injury].apply_on_status
 	local statusTab = tabBar:AddTabItem("Apply On Status")
+	statusTab.TextWrapPos = 0
 
 	statusTab:AddText("How many total (non-consecutive, aggregated) rounds should the below statuses be on a character before the Injury is applied?")
 	local statusRounds = statusTab:AddSliderInt("", applyOnConfig["number_of_rounds"], 1, 30)

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Client/Injuries/Tabs/ApplyOnStatusTab.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Client/Injuries/Tabs/ApplyOnStatusTab.lua
@@ -31,6 +31,11 @@ local function BuildRows(statusTable, status, applyOnConfig, ignoreExistingStatu
 		statusConfig["multiplier"] = slider.Value[1]
 	end
 
+	local guaranteeApplicationCheckbox = row:AddCell():AddCheckbox("", statusConfig["guarantee_application"])
+	guaranteeApplicationCheckbox.OnChange = function ()
+		statusConfig["guarantee_application"] = guaranteeApplicationCheckbox.Checked
+	end
+
 	local deleteRowButton = row:AddCell():AddButton("Delete")
 	deleteRowButton.OnClick = function()
 		statusConfig.delete = true
@@ -58,14 +63,14 @@ InjuryMenu:RegisterTab(function(tabBar, injury)
 
 	statusTab:AddNewLine()
 
-	local statusTable = statusTab:AddTable("ApplyOnStatus", 3)
-	statusTable.BordersInnerH = true
+	local statusTable = statusTab:AddTable("ApplyOnStatus", 4)
 	statusTable.Resizable = true
 
 	local headerRow = statusTable:AddRow()
 	headerRow.Headers = true
 	headerRow:AddCell():AddText("Status Name (ResourceID)")
 	headerRow:AddCell():AddText("Round # Multiplier")
+	headerRow:AddCell():AddText("Guarantee Injury Application (?)"):Tooltip():AddText("\t\t If the chance for injury application is less than 100% (General Rules tab), then checking this box will ignore that and apply the injury 100% of the time (if this status is the one that triggers the injury)").TextWrapPos = 600
 
 	DataSearchHelper:BuildSearch(statusTab,
 		Ext.Stats.GetStats("StatusData"),

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Client/Injuries/Tabs/CharacterMultipliers.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Client/Injuries/Tabs/CharacterMultipliers.lua
@@ -27,6 +27,7 @@ InjuryMenu:RegisterTab(function(tabBar, injury)
 	local charMultiplierConfig = InjuryMenu.ConfigurationSlice.injury_specific[injury].character_multipliers
 
 	local multiplierTab = tabBar:AddTabItem("Character Multipliers")
+	multiplierTab.TextWrapPos = 0
 
 	--#region Races
 	local raceHeader = multiplierTab:AddCollapsingHeader("Races")

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Client/Injuries/Tabs/DamageTab.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Client/Injuries/Tabs/DamageTab.lua
@@ -48,6 +48,7 @@ InjuryMenu:RegisterTab(function(tabBar, injury)
 	local damageConfig = InjuryMenu.ConfigurationSlice.injury_specific[injury].damage
 
 	local damageTab = tabBar:AddTabItem("Damage")
+	damageTab.TextWrapPos = 0
 
 	damageTab:AddText("Applied after total damage from all configured DamageTypes is >= the following % of Health:")
 	local damageThreshold = damageTab:AddSliderInt("", damageConfig["threshold"], 0, 100)

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Client/Injuries/Tabs/GeneralRulesTab.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Client/Injuries/Tabs/GeneralRulesTab.lua
@@ -1,0 +1,29 @@
+--- @param tabBar ExtuiTabBar
+--- @param injury InjuryName
+InjuryMenu:RegisterTab(function(tabBar, injury)
+	local generalRulesTab = tabBar:AddTabItem("General Rules")
+
+	InjuryMenu.ConfigurationSlice.injury_specific[injury].chance_of_application = InjuryMenu.ConfigurationSlice.injury_specific[injury].chance_of_application or 100
+
+	generalRulesTab:AddText("What's the % chance of this Injury being applied when conditions are met?")
+	generalRulesTab:AddText("Due to technical limitations, this can't be a save - it's just a flat roll out of 100"):SetStyle("Alpha", 0.7)
+	local chanceToApplySlider = generalRulesTab:AddSliderInt("", InjuryMenu.ConfigurationSlice.injury_specific[injury].chance_of_application, 1, 100)
+
+	chanceToApplySlider.OnChange = function()
+		InjuryMenu.ConfigurationSlice.injury_specific[injury].chance_of_application = chanceToApplySlider.Value[1]
+	end
+
+	generalRulesTab:AddNewLine()
+
+	---@type StatusData
+	local injuryStat = Ext.Stats.Get(injury)
+	if injuryStat.StackId and injuryStat.StackId ~= "" and injuryStat.StackPriority > 1 then
+		generalRulesTab:AddText("How many stacks should be removed when this status is removed?")
+		generalRulesTab:AddText("i.e. if you set 3rd Degree Burns to remove 2 stacks, you'll have 1st Degree Burns applied"):SetStyle("Alpha", 0.7)
+		InjuryMenu.ConfigurationSlice.injury_specific[injury].stacks_to_remove = injuryStat.StackPriority
+		local stackRemovalSlider = generalRulesTab:AddSliderInt("", injuryStat.StackPriority, 1, injuryStat.StackPriority)
+		stackRemovalSlider.OnChange = function()
+			InjuryMenu.ConfigurationSlice.injury_specific[injury].stacks_to_remove = stackRemovalSlider.Value[1]
+		end
+	end
+end)

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Client/Injuries/Tabs/GeneralRulesTab.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Client/Injuries/Tabs/GeneralRulesTab.lua
@@ -13,17 +13,4 @@ InjuryMenu:RegisterTab(function(tabBar, injury)
 		InjuryMenu.ConfigurationSlice.injury_specific[injury].chance_of_application = chanceToApplySlider.Value[1]
 	end
 
-	generalRulesTab:AddNewLine()
-
-	---@type StatusData
-	local injuryStat = Ext.Stats.Get(injury)
-	if injuryStat.StackId and injuryStat.StackId ~= "" and injuryStat.StackPriority > 1 then
-		generalRulesTab:AddText("How many stacks should be removed when this status is removed?")
-		generalRulesTab:AddText("i.e. if you set 3rd Degree Burns to remove 2 stacks, you'll have 1st Degree Burns applied"):SetStyle("Alpha", 0.7)
-		InjuryMenu.ConfigurationSlice.injury_specific[injury].stacks_to_remove = injuryStat.StackPriority
-		local stackRemovalSlider = generalRulesTab:AddSliderInt("", injuryStat.StackPriority, 1, injuryStat.StackPriority)
-		stackRemovalSlider.OnChange = function()
-			InjuryMenu.ConfigurationSlice.injury_specific[injury].stacks_to_remove = stackRemovalSlider.Value[1]
-		end
-	end
 end)

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Client/Injuries/Tabs/RemoveOnStatusTab.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Client/Injuries/Tabs/RemoveOnStatusTab.lua
@@ -80,6 +80,7 @@ InjuryMenu:RegisterTab(function(tabBar, injury)
 	local removeOnConfig = InjuryMenu.ConfigurationSlice.injury_specific[injury].remove_on_status
 
 	local statusTab = tabBar:AddTabItem("Remove On Status")
+	statusTab.TextWrapPos = 0
 
 	local statusTable = statusTab:AddTable("RemoveOnStatus", 3)
 	statusTable.BordersInnerH = true

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Client/Injuries/Tabs/RemoveOnStatusTab.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Client/Injuries/Tabs/RemoveOnStatusTab.lua
@@ -71,6 +71,7 @@ local function BuildRows(statusTable, status, injury, removeOnConfig, ignoreExis
 			statusConfig.stacks_to_remove = stackRemovalSlider.Value[1]
 		end
 	end
+
 	--#endregion
 
 	local deleteRowButton = row:AddCell():AddButton("Delete")
@@ -107,8 +108,7 @@ InjuryMenu:RegisterTab(function(tabBar, injury)
 	headerRow:AddCell():AddText("Status Name (ResourceID)")
 	headerRow:AddCell():AddText("Save Conditions")
 	if addStackRemovalAspect then
-		headerRow:AddCell():AddText("# of Stacks To Remove")
-		-- stackCell:AddText("i.e. if you set 3rd Degree Burns to remove 2 stacks, you'll have 1st Degree Burns applied"):SetStyle("Alpha", 0.7)
+		headerRow:AddCell():AddText("# of Stacks To Remove (?)"):Tooltip():AddText("i.e. if you set 3rd Degree Burns to remove 2 stacks, you'll have 1st Degree Burns applied")
 	end
 
 	DataSearchHelper:BuildSearch(statusTab,

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Client/Injuries/Tabs/RemoveOnStatusTab.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Client/Injuries/Tabs/RemoveOnStatusTab.lua
@@ -31,7 +31,9 @@ local function BuildRows(statusTable, status, injury, removeOnConfig, ignoreExis
 	--#region Save Options
 	local saveOptions = {}
 	for _, ability in ipairs(Ext.Enums.AbilityId) do
-		table.insert(saveOptions, tostring(ability))
+		if ability ~= "Sentinel" then
+			table.insert(saveOptions, tostring(ability))
+		end
 	end
 	table.sort(saveOptions)
 	table.insert(saveOptions, 1, "No Save")

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Client/Injuries/Tabs/RemoveOnStatusTab.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Client/Injuries/Tabs/RemoveOnStatusTab.lua
@@ -1,9 +1,10 @@
 ---@param statusTable ExtuiTable
 ---@param status string
+---@param injury InjuryName
 ---@param removeOnConfig InjuryRemoveOnStatusClass
 ---@param ignoreExistingStatus boolean?
-local function BuildRows(statusTable, status, removeOnConfig, ignoreExistingStatus)
-	---@type StatsObject
+local function BuildRows(statusTable, status, injury, removeOnConfig, ignoreExistingStatus)
+	---@type StatusData
 	local statusObj = Ext.Stats.Get(status)
 
 	local statusName = statusObj.Name
@@ -35,8 +36,8 @@ local function BuildRows(statusTable, status, removeOnConfig, ignoreExistingStat
 	table.sort(saveOptions)
 	table.insert(saveOptions, 1, "No Save")
 
-	local saveRow = row:AddCell()
-	local saveCombo = saveRow:AddCombo("")
+	local saveCell = row:AddCell()
+	local saveCombo = saveCell:AddCombo("")
 	saveCombo.Options = saveOptions
 	for index, option in pairs(saveCombo.Options) do
 		if option == statusConfig["ability"] then
@@ -45,7 +46,7 @@ local function BuildRows(statusTable, status, removeOnConfig, ignoreExistingStat
 		end
 	end
 
-	local saveSlider = saveRow:AddSliderInt("",
+	local saveSlider = saveCell:AddSliderInt("",
 		statusConfig["difficulty_class"],
 		1,
 		30)
@@ -58,6 +59,17 @@ local function BuildRows(statusTable, status, removeOnConfig, ignoreExistingStat
 	saveCombo.OnChange = function(combo, selectedIndex)
 		saveSlider.Visible = selectedIndex ~= 0
 		statusConfig["ability"] = saveCombo.Options[selectedIndex + 1]
+	end
+
+	---@type StatusData
+	local injuryStat = Ext.Stats.Get(injury)
+	if injuryStat.StackId and injuryStat.StackId ~= "" and injuryStat.StackPriority > 1 then
+		local stackCell = row:AddCell()
+		statusConfig.stacks_to_remove = statusConfig.stacks_to_remove or injuryStat.StackPriority
+		local stackRemovalSlider = stackCell:AddSliderInt("", statusConfig.stacks_to_remove, 1, injuryStat.StackPriority)
+		stackRemovalSlider.OnChange = function()
+			statusConfig.stacks_to_remove = stackRemovalSlider.Value[1]
+		end
 	end
 	--#endregion
 
@@ -82,7 +94,11 @@ InjuryMenu:RegisterTab(function(tabBar, injury)
 	local statusTab = tabBar:AddTabItem("Remove On Status")
 	statusTab.TextWrapPos = 0
 
-	local statusTable = statusTab:AddTable("RemoveOnStatus", 3)
+	---@type StatusData
+	local injuryStat = Ext.Stats.Get(injury)
+	local addStackRemovalAspect = injuryStat.StackId and injuryStat.StackId ~= "" and injuryStat.StackPriority > 1
+
+	local statusTable = statusTab:AddTable("RemoveOnStatus", addStackRemovalAspect and 4 or 3)
 	statusTable.BordersInnerH = true
 	statusTable.Resizable = true
 
@@ -90,6 +106,10 @@ InjuryMenu:RegisterTab(function(tabBar, injury)
 	headerRow.Headers = true
 	headerRow:AddCell():AddText("Status Name (ResourceID)")
 	headerRow:AddCell():AddText("Save Conditions")
+	if addStackRemovalAspect then
+		headerRow:AddCell():AddText("# of Stacks To Remove")
+		-- stackCell:AddText("i.e. if you set 3rd Degree Burns to remove 2 stacks, you'll have 1st Degree Burns applied"):SetStyle("Alpha", 0.7)
+	end
 
 	DataSearchHelper:BuildSearch(statusTab,
 		Ext.Stats.GetStats("StatusData"),
@@ -97,10 +117,10 @@ InjuryMenu:RegisterTab(function(tabBar, injury)
 			return Ext.Loca.GetTranslatedString(Ext.Stats.Get(resourceId).DisplayName, nil)
 		end,
 		function(status)
-			BuildRows(statusTable, status, removeOnConfig, true)
+			BuildRows(statusTable, status, injury, removeOnConfig, true)
 		end)
 
 	for status, _ in pairs(removeOnConfig) do
-		BuildRows(statusTable, status, removeOnConfig)
+		BuildRows(statusTable, status, injury, removeOnConfig)
 	end
 end)

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Server/Injuries/_ApplyOnStatus.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Server/Injuries/_ApplyOnStatus.lua
@@ -10,7 +10,7 @@ local function processInjuries(entity, status, statusConfig, injuryVar)
 
 	for injury, injuryStatusConfig in pairs(statusConfig) do
 		local nextStackInjury = InjuryConfigHelper:GetNextInjuryInStackIfApplicable(character, injury)
-		if Osi.HasActiveStatus(character, nextStackInjury) == 0 then
+		if nextStackInjury and Osi.HasActiveStatus(character, nextStackInjury) == 0 then
 			local injuryConfig = ConfigManager.ConfigCopy.injuries.injury_specific[injury]
 
 			if not statusVar[status] then

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Server/Injuries/_ApplyOnStatus.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Server/Injuries/_ApplyOnStatus.lua
@@ -34,7 +34,7 @@ local function processInjuries(entity, status, statusConfig, injuryVar)
 			local characterMultiplier = InjuryConfigHelper:CalculateCharacterMultipliers(entity, injuryConfig)
 			roundsWithMultiplier = roundsWithMultiplier * characterMultiplier * npcMultiplier
 
-			if roundsWithMultiplier >= injuryConfig.apply_on_status["number_of_rounds"] then
+			if roundsWithMultiplier >= injuryConfig.apply_on_status["number_of_rounds"] and InjuryConfigHelper:RollForApplication(nextStackInjury, injuryVar) then
 				Osi.ApplyStatus(character, nextStackInjury, -1)
 				injuryVar["injuryAppliedReason"][nextStackInjury] = "Status"
 

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Server/Injuries/_ApplyOnStatus.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Server/Injuries/_ApplyOnStatus.lua
@@ -34,7 +34,7 @@ local function processInjuries(entity, status, statusConfig, injuryVar)
 			local characterMultiplier = InjuryConfigHelper:CalculateCharacterMultipliers(entity, injuryConfig)
 			roundsWithMultiplier = roundsWithMultiplier * characterMultiplier * npcMultiplier
 
-			if roundsWithMultiplier >= injuryConfig.apply_on_status["number_of_rounds"] and InjuryConfigHelper:RollForApplication(nextStackInjury, injuryVar) then
+			if roundsWithMultiplier >= injuryConfig.apply_on_status["number_of_rounds"] and InjuryConfigHelper:RollForApplication(nextStackInjury, injuryVar, status) then
 				Osi.ApplyStatus(character, nextStackInjury, -1)
 				injuryVar["injuryAppliedReason"][nextStackInjury] = "Status"
 

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Server/Injuries/_Damage.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Server/Injuries/_Damage.lua
@@ -86,7 +86,7 @@ local function ProcessDamageEvent(event)
 
 						local totalHpPercentageRemoved = (finalDamageWithInjuryMultiplier / defenderEntity.Health.MaxHp) * 100
 
-						if totalHpPercentageRemoved >= injuryConfig.damage["threshold"] then
+						if totalHpPercentageRemoved >= injuryConfig.damage["threshold"] and InjuryConfigHelper:RollForApplication(nextStackInjury, injuryVar) then
 							Osi.ApplyStatus(defender, nextStackInjury, -1)
 							injuryVar["injuryAppliedReason"][nextStackInjury] = "Damage"
 

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Server/Injuries/_Damage.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Server/Injuries/_Damage.lua
@@ -4,6 +4,10 @@ local defender
 local function ProcessDamageEvent(event)
 	local defenderEntity, injuryVar = InjuryConfigHelper:GetUserVar(defender)
 
+	if not defenderEntity or not injuryVar then
+		return
+	end
+
 	-- Damage numbers don't account for TempHp - need to recreate that reduction
 	--- @type { [DamageType] : integer }
 	local tempHpReductionTable = {}
@@ -92,6 +96,10 @@ local function ProcessDamageEvent(event)
 							injuryVar["injuryAppliedReason"][nextStackInjury] = "Damage"
 
 							if injury ~= nextStackInjury then
+								for _, entry in pairs(injuryVar["damage"]) do
+									entry[nextStackInjury] = entry[injury]
+									entry[injury] = nil
+								end
 								injuryVar["injuryAppliedReason"][nextStackInjury] = string.format("Damage (Stacked on top of %s)",
 									Ext.Loca.GetTranslatedString(Ext.Stats.Get(injury).DisplayName, injury))
 							end

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Server/Injuries/_Damage.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Server/Injuries/_Damage.lua
@@ -49,7 +49,8 @@ local function ProcessDamageEvent(event)
 					local injuryConfig = ConfigManager.ConfigCopy.injuries.injury_specific[injury]
 					local nextStackInjury = InjuryConfigHelper:GetNextInjuryInStackIfApplicable(defender, injury)
 
-					if Osi.HasActiveStatus(defender, nextStackInjury) == 0
+					if nextStackInjury
+						and Osi.HasActiveStatus(defender, nextStackInjury) == 0
 						and not injuryVar["injuryAppliedReason"][nextStackInjury]
 					then
 						local finalDamageWithPreviousDamage = finalDamageAmount

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Server/Injuries/_Healing.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Server/Injuries/_Healing.lua
@@ -8,7 +8,7 @@ Ext.Vars.RegisterUserVariable("Injuries_Healing", {
 Ext.Entity.Subscribe("Health", function(entity, _, _)
 	local _, injuryVar = InjuryConfigHelper:GetUserVar(entity.Uuid.EntityUuid)
 	local damageVar = injuryVar["damage"]
-	if damageVar and next(damageVar) and ConfigManager.ConfigCopy.injuries.universal.healing_subtracts_injury_damage then
+	if damageVar and next(damageVar) and ConfigManager.ConfigCopy.injuries and ConfigManager.ConfigCopy.injuries.universal.healing_subtracts_injury_damage then
 		---@type HealthComponent
 		local healthComp = entity.Health
 

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Server/Injuries/_RandomInjuryOnCondition.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Server/Injuries/_RandomInjuryOnCondition.lua
@@ -46,8 +46,8 @@ function RandomInjuryOnConditionProcessor:ProcessDamageEvent(event, defender, te
 
 					for injury, _ in pairs(injuryPool) do
 						local injuryToApply = InjuryConfigHelper:GetNextInjuryInStackIfApplicable(defender, injury)
-						
-						if Osi.HasActiveStatus(defender,  injuryToApply) == 0
+						if injuryToApply
+							and Osi.HasActiveStatus(defender, injuryToApply) == 0
 							and severityToChoose == ConfigManager.ConfigCopy.injuries.injury_specific[injuryToApply].severity
 							and not alreadySelectedInjuries[injuryToApply]
 						then
@@ -123,11 +123,11 @@ EventCoordinator:RegisterEventProcessor("StatusApplied", function(character, sta
 
 			for injury, _ in pairs(injuryPool) do
 				injury = InjuryConfigHelper:GetNextInjuryInStackIfApplicable(character, injury)
-				
-				if Osi.HasActiveStatus(character, injury) == 0
+
+				if injury
+					and Osi.HasActiveStatus(character, injury) == 0
 					and severityToChoose == ConfigManager.ConfigCopy.injuries.injury_specific[injury].severity
 					and not alreadySelectedInjuries[injury]
-					and not InjuryConfigHelper:GetNextInjuryInStackIfApplicable(character, injury)
 				then
 					table.insert(eligibleInjuries, injury)
 					alreadySelectedInjuries[injury] = true

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Server/Injuries/_RemoveOnStatus.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Server/Injuries/_RemoveOnStatus.lua
@@ -1,8 +1,14 @@
 ---@param character GUIDSTRING
 ---@param injury InjuryName
 ---@param injuryConfig InjuryRemoveOnStatus
-local function removeInjury(character, injury, injuryConfig)
+---@param statusCausingRemoval string
+local function removeInjury(character, injury, injuryConfig, statusCausingRemoval)
 	if injuryConfig["ability"] == "No Save" or injuryConfig["ability"] == "None" then
+		local entity, injuryVar = InjuryConfigHelper:GetUserVar(character)
+		injuryVar["removedDueTo"] = injuryVar["removedDueTo"] or {}
+		injuryVar["removedDueTo"][injury] = statusCausingRemoval
+		InjuryConfigHelper:UpdateUserVar(entity, injuryVar)
+
 		Osi.RemoveStatus(character, injury)
 	else
 		Osi.RequestPassiveRoll(character,
@@ -34,7 +40,7 @@ EventCoordinator:RegisterEventProcessor("StatusApplied", function(character, sta
 		local numInjuriesToRemove = ConfigManager.ConfigCopy.injuries.universal.how_many_injuries_can_be_removed_at_once
 		if numInjuriesToRemove == "All" then
 			for injuryToRemove, injuryConfig in pairs(injuriesToRemove) do
-				removeInjury(character, injuryToRemove, injuryConfig)
+				removeInjury(character, injuryToRemove, injuryConfig, status)
 			end
 		elseif numInjuriesToRemove == "One" then
 			local indexedTable = {}
@@ -69,17 +75,22 @@ EventCoordinator:RegisterEventProcessor("StatusApplied", function(character, sta
 			end
 			local injuryToRemove = indexedTable[Osi.Random(#indexedTable) + 1]
 
-			removeInjury(character, injuryToRemove, injuriesToRemove[injuryToRemove])
+			removeInjury(character, injuryToRemove, injuriesToRemove[injuryToRemove], status)
 		end
 	end
 end)
 
 EventCoordinator:RegisterEventProcessor("RollResult", function(eventName, roller, rollSubject, resultType, isActiveRoll, criticality)
 	if string.find(eventName, "Goon_Injuries_Remove_Injury_") then
-		local injuryName = string.sub(eventName, string.len("Goon_Injuries_Remove_Injury_"))
-
+		local injuryNameAndStatus = string.sub(eventName, string.len("Goon_Injuries_Remove_Injury_"))
+		local injuryName, statusCausingRemoval = string.match(injuryNameAndStatus, "([^|]+)|([^|]+)")
 		if resultType == 1 then
-			Osi.RemoveStatus(roller, injuryName)
+			local entity, injuryVar = InjuryConfigHelper:GetUserVar(character)
+			injuryVar["removedDueTo"] = injuryVar["removedDueTo"] or {}
+			injuryVar["removedDueTo"][injury] = statusCausingRemoval
+			InjuryConfigHelper:UpdateUserVar(entity, injuryVar)
+			
+			Osi.RemoveStatus(roller, injuryName, statusCausingRemoval)
 		end
 	end
 end)

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Server/Injuries/_RemoveOnStatus.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Server/Injuries/_RemoveOnStatus.lua
@@ -17,7 +17,7 @@ local function removeInjury(character, injury, injuryConfig, statusCausingRemova
 			injuryConfig["ability"],
 			DifficultyClassMap[injuryConfig["difficulty_class"]],
 			0,
-			"Goon_Injuries_Remove_Injury_" .. injury)
+			"Goon_Injuries_Remove_Injury_" .. injury .. "|" .. statusCausingRemoval)
 	end
 end
 
@@ -87,9 +87,9 @@ EventCoordinator:RegisterEventProcessor("RollResult", function(eventName, roller
 		if resultType == 1 then
 			local entity, injuryVar = InjuryConfigHelper:GetUserVar(character)
 			injuryVar["removedDueTo"] = injuryVar["removedDueTo"] or {}
-			injuryVar["removedDueTo"][injury] = statusCausingRemoval
+			injuryVar["removedDueTo"][injuryName] = statusCausingRemoval
 			InjuryConfigHelper:UpdateUserVar(entity, injuryVar)
-			
+
 			Osi.RemoveStatus(roller, injuryName, statusCausingRemoval)
 		end
 	end

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Shared/Injuries/_ConfigHelper.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Shared/Injuries/_ConfigHelper.lua
@@ -162,7 +162,7 @@ if Ext.IsServer() then
 	--- If an eligible injury shares a stack with an applied injury, and is not the next injury in the stack, find the injury with the next
 	--- highest stackPriority (of the applied injury)
 	---@param character GUIDSTRING
-	---@param injury InjuryName
+	---@param injury InjuryName?
 	function InjuryConfigHelper:GetNextInjuryInStackIfApplicable(character, injury)
 		---@type StatusData
 		local injuryEntry = Ext.Stats.Get(injury)
@@ -188,6 +188,8 @@ if Ext.IsServer() then
 							return configuredInjuryName
 						end
 					end
+					-- If we're at the highest stack, don't bother continuing
+					return nil
 				end
 			end
 		end

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Shared/Injuries/_ConfigHelper.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Shared/Injuries/_ConfigHelper.lua
@@ -143,9 +143,11 @@ if Ext.IsServer() then
 
 	---@param injuryName InjuryName
 	---@param existingInjuryVar InjuryVar
-	function InjuryConfigHelper:RollForApplication(injuryName, existingInjuryVar)
-		local chanceOfApplication = ConfigManager.ConfigCopy.injuries.injury_specific[injuryName].chance_of_application
-		if not chanceOfApplication or chanceOfApplication == 100 then
+	---@param status string?
+	function InjuryConfigHelper:RollForApplication(injuryName, existingInjuryVar, status)
+		local injuryConfig = ConfigManager.ConfigCopy.injuries.injury_specific[injuryName]
+		local chanceOfApplication = injuryConfig.chance_of_application
+		if not chanceOfApplication or chanceOfApplication == 100 or (status and injuryConfig.apply_on_status["applicable_statuses"][status]["guarantee_application"]) then
 			return true
 		end
 
@@ -155,7 +157,7 @@ if Ext.IsServer() then
 
 		existingInjuryVar["numberOfApplicationsAttempted"][injuryName] = (existingInjuryVar["numberOfApplicationsAttempted"][injuryName] or 0) + 1
 
-		local randomNumber = Ext.Math.Random(0, 100)
+		local randomNumber = Osi.Random(100) + 1
 		return randomNumber <= chanceOfApplication
 	end
 

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Shared/Injuries/_ConfigHelper.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Shared/Injuries/_ConfigHelper.lua
@@ -16,6 +16,7 @@ local injuryVar = {
 	["applyOnStatus"] = {},
 	---@type {[InjuryName] : string}
 	["injuryAppliedReason"] = {},
+	["numberOfApplicationsAttempted"] = 0
 }
 
 InjuryConfigHelper = {}
@@ -272,7 +273,7 @@ if Ext.IsServer() then
 		if Osi.IsItem(character) == 0 then
 			local entity, injuryUserVar = InjuryConfigHelper:GetUserVar(character)
 
-			if entity and injuryUserVar then
+			if entity and injuryUserVar and injuryUserVar["injuryAppliedReason"] then
 				if injuryUserVar["injuryAppliedReason"][status] then
 					for damageType, injuryTable in pairs(injuryUserVar["damage"]) do
 						injuryTable[status] = nil

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Shared/Injuries/_ConfigHelper.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Shared/Injuries/_ConfigHelper.lua
@@ -313,7 +313,8 @@ if Ext.IsServer() then
 								---@type StatusData
 								local otherInjuryStat = Ext.Stats.Get(otherInjury)
 								if otherInjuryStat.StackId == injuryStat.StackId then
-									if injuryUserVar["injuryAppliedReason"][otherInjury] and otherInjuryStat.StackPriority >= injuryStat.StackPriority then
+									if injuryUserVar["injuryAppliedReason"][otherInjury] and otherInjuryStat.StackPriority > injuryStat.StackPriority then
+										injuryToMoveTo = nil
 										break
 									end
 
@@ -321,7 +322,6 @@ if Ext.IsServer() then
 										injuryToMoveTo = otherInjury
 										Osi.ApplyStatus(character, injuryToMoveTo, -1, 1)
 										injuryUserVar["injuryAppliedReason"][injuryToMoveTo] = "Removal of " .. (Ext.Loca.GetTranslatedString(injuryStat.DisplayName, injury))
-										break
 									end
 								end
 							end

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Shared/Injuries/_InjuryConfig.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Shared/Injuries/_InjuryConfig.lua
@@ -80,9 +80,6 @@ ConfigurationStructure.DynamicClassDefinitions.injury_class.severity = "Medium"
 ---@type number
 ConfigurationStructure.DynamicClassDefinitions.injury_class.chance_of_application = 100
 
----@type number?
-ConfigurationStructure.DynamicClassDefinitions.injury_class.stacks_to_remove = nil
-
 ---@class InjuryDamageTypeClass
 ConfigurationStructure.DynamicClassDefinitions.injury_damage_type_class = {
 	["multiplier"] = 1
@@ -99,7 +96,9 @@ ConfigurationStructure.DynamicClassDefinitions.injury_class.damage = {
 ConfigurationStructure.DynamicClassDefinitions.injury_remove_on_status_class = {
 	---@type AbilityId|"No Save"
 	["ability"] = "No Save",
-	["difficulty_class"] = 15
+	["difficulty_class"] = 15,
+	---@type number?
+	stacks_to_remove = nil
 }
 
 ---@alias StatusName string

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Shared/Injuries/_InjuryConfig.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Shared/Injuries/_InjuryConfig.lua
@@ -73,9 +73,11 @@ ConfigurationStructure.config.injuries.universal.random_injury_filter_by_damage_
 ---@class Injury
 ConfigurationStructure.DynamicClassDefinitions.injury_class = {}
 
----@alias severity "Low"|"Medium"|"High"
+---@alias severity "Exclude"|"Low"|"Medium"|"High"
 ---@type severity
 ConfigurationStructure.DynamicClassDefinitions.injury_class.severity = "Medium"
+
+ConfigurationStructure.DynamicClassDefinitions.injury_class.include_in_random_table = true
 
 ---@type number
 ConfigurationStructure.DynamicClassDefinitions.injury_class.chance_of_application = 100
@@ -108,7 +110,8 @@ ConfigurationStructure.DynamicClassDefinitions.injury_class.remove_on_status = {
 
 ---@class InjuryApplyOnStatusModifierClass
 ConfigurationStructure.DynamicClassDefinitions.injury_apply_on_status_class = {
-	["multiplier"] = 1
+	["multiplier"] = 1,
+	["guarantee_application"] = false,
 }
 ---@class InjuryApplyOnStatusClass
 ConfigurationStructure.DynamicClassDefinitions.injury_class.apply_on_status = {

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Shared/Injuries/_InjuryConfig.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Shared/Injuries/_InjuryConfig.lua
@@ -77,6 +77,12 @@ ConfigurationStructure.DynamicClassDefinitions.injury_class = {}
 ---@type severity
 ConfigurationStructure.DynamicClassDefinitions.injury_class.severity = "Medium"
 
+---@type number
+ConfigurationStructure.DynamicClassDefinitions.injury_class.chance_of_application = 100
+
+---@type number?
+ConfigurationStructure.DynamicClassDefinitions.injury_class.stacks_to_remove = nil
+
 ---@class InjuryDamageTypeClass
 ConfigurationStructure.DynamicClassDefinitions.injury_damage_type_class = {
 	["multiplier"] = 1

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Shared/Utils/_TableUtils.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Shared/Utils/_TableUtils.lua
@@ -65,3 +65,52 @@ function TableUtils:CompareLists(first, second)
 
 	return true
 end
+
+--- Custom pairs function that iterates over a table with alphanumeric indexes in alphabetical order
+--- Optionally accepts a function to transform the key for sorting and returning
+---@param t table
+---@param keyTransformFunc function?
+---@return function
+function TableUtils:OrderedPairs(t, keyTransformFunc)
+	local keys = {}
+	for k in pairs(t) do
+		table.insert(keys, k)
+	end
+	table.sort(keys, function(a, b)
+		local keyA = keyTransformFunc and keyTransformFunc(a) or tostring(a)
+		local keyB = keyTransformFunc and keyTransformFunc(b) or tostring(b)
+		return keyA < keyB
+	end)
+
+	local i = 0
+	return function()
+		i = i + 1
+		if keys[i] then
+			local key = keys[i]
+			return key, t[key]
+		end
+	end
+end
+
+---@param list table
+---@param str string
+---@return boolean, any?
+function TableUtils:ListContains(list, str)
+	for i, value in pairs(list) do
+		if value == str then
+			return true, i
+		end
+	end
+	return false
+end
+
+--- Get a count of all elements in a table with a non-numeric index
+---@param t table
+---@return number
+function TableUtils:CountEntries(t)
+	local count = 0
+	for _, _ in pairs(t) do
+		count = count + 1
+	end
+	return count
+end


### PR DESCRIPTION
- Fixes customization windows defaulting to tall and narrow
- Removes `Sentinel` as an option for throws
- Adds Severity option `exclude` to exclude from severity randomization table
- Implements % based application chance
  - Adds guarantee checkbox for ApplyOnStatus 
- Implements partial stack removal
- forget what else