### PR TITLE
Npc multiplier per injury

### DIFF
--- a/Injuries/Localization/English/Injuries.loca.xml
+++ b/Injuries/Localization/English/Injuries.loca.xml
@@ -75,7 +75,7 @@ Completing a &lt;LSTag Tooltip="ShortRest"&gt;Short Rest&lt;/LSTag&gt; will remo
 	<content contentuid="hb2b2ef0a495543a4a5596f821e25226410a7" version="1">Allies</content>
 	<content contentuid="h67f450fc249442b795305a91a9119e3e3790" version="1">Enemies</content>
 	<content contentuid="hfec50ba697d0499987092544aaf9805ed6e0" version="1">How Many Injuries Can Be Applied In One Event?</content>
-    <content contentuid="hd9f5ee0de95740d385213d6cdc1e00fa1006" version="1">Event refers to triggers like an attack or status application. Injuries are processed randomly and on a first-come, first-serve basis, and only injuries that are actually applied will be counted</content>
+	<content contentuid="hd9f5ee0de95740d385213d6cdc1e00fa1006" version="1">Event refers to triggers like an attack or status application. Injuries are processed randomly and on a first-come, first-serve basis, and only injuries that are actually applied will be counted</content>
 	<content contentuid="hf09a78e9f67d4f6ebd69b1831b16bc7e00cf" version="1">How Many Different Injuries Can Be Removed At Once?</content>
 	<content contentuid="h917674e930d34cc8a28ecc9051066f4f332f" version="1">If multiple injuries share the same removal conditions, only the specified number will be removed at once - injuries will be randomly chosen.</content>
 	<content contentuid="he8141a6f94e24224a4cdd5f198aca85703b6" version="1">All</content>

--- a/Injuries/Localization/English/Injuries.loca.xml
+++ b/Injuries/Localization/English/Injuries.loca.xml
@@ -74,6 +74,8 @@ Completing a &lt;LSTag Tooltip="ShortRest"&gt;Short Rest&lt;/LSTag&gt; will remo
 	<content contentuid="h9df2a1fcaea949aeb733c493d4d7045ad3d3" version="1">Party Members</content>
 	<content contentuid="hb2b2ef0a495543a4a5596f821e25226410a7" version="1">Allies</content>
 	<content contentuid="h67f450fc249442b795305a91a9119e3e3790" version="1">Enemies</content>
+	<content contentuid="hfec50ba697d0499987092544aaf9805ed6e0" version="1">How Many Injuries Can Be Applied In One Event?</content>
+    <content contentuid="hd9f5ee0de95740d385213d6cdc1e00fa1006" version="1">Event refers to triggers like an attack or status application. Injuries are processed randomly and on a first-come, first-serve basis, and only injuries that are actually applied will be counted</content>
 	<content contentuid="hf09a78e9f67d4f6ebd69b1831b16bc7e00cf" version="1">How Many Different Injuries Can Be Removed At Once?</content>
 	<content contentuid="h917674e930d34cc8a28ecc9051066f4f332f" version="1">If multiple injuries share the same removal conditions, only the specified number will be removed at once - injuries will be randomly chosen.</content>
 	<content contentuid="he8141a6f94e24224a4cdd5f198aca85703b6" version="1">All</content>
@@ -204,6 +206,8 @@ Completing a &lt;LSTag Tooltip="ShortRest"&gt;Short Rest&lt;/LSTag&gt; will remo
     <content contentuid="h72738de2d12d41798d6780e4512bef70a9g1" version="1">Tag UUID:</content>
     <content contentuid="h56eb6fe545af4fe3b335bc5483844b98be02" version="1">Display Description:</content>
     <content contentuid="h55fb845d61da4b6ba21457c35b05edfc672g" version="1">Delete</content>
+	<content contentuid="hf711296ce96b4c9e8dd776fda7c9755680b0" version="1">These % multipliers will apply after the ones set per-injury (0 = no Injury damage will be taken) - NPC-type determinations are made by their associated Experience Reward Category. These will override the ones set in the universal 'Applying Injuries' settings. Supports Mod-added XPReward categories as long as they use the same names prepended with `_` - e.g. MMM_Combatant</content>
+    <content contentuid="hfb5b81035983400b974aa2f4aec01a1e369b" version="1">Damage + Status Multipliers For NPCs</content>
 	<!-- END Character Multipliers Tab -->
 
 	<!-- BEGIN Apply On Status Tab -->
@@ -237,6 +241,4 @@ NOTE: This section does not currently handle ticks, it is only handling initial 
     <content contentuid="he1723b1c477144bd9e4c69594b60f64f6a9b" version="1">Include</content>
     <content contentuid="hcfc9c68627ac4cd9a365d94a32e48c0cc4fd" version="1">Exclude</content>
 	<!-- END Status Helper -->
-    <content contentuid="hfec50ba697d0499987092544aaf9805ed6e0" version="1">How Many Injuries Can Be Applied In One Event?</content>
-    <content contentuid="hd9f5ee0de95740d385213d6cdc1e00fa1006" version="1">Event refers to triggers like an attack or status application. Injuries are processed randomly and on a first-come, first-serve basis, and only injuries that are actually applied will be counted</content>
 </contentList>

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Client/Injuries/InjuryReport.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Client/Injuries/InjuryReport.lua
@@ -140,7 +140,6 @@ local function CreateReport(group)
 	reportButton:Tooltip():AddText("\tClick To Toggle")
 
 	local reportTable = group:AddTable(group.UserData .. "Report", 4)
-	-- reportTable:AddColumn("First", "WidthFixed")
 	reportTable.SizingStretchSame = true
 	reportTable.BordersInnerH = true
 	reportTable.Visible = false

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Client/Injuries/InjuryReport.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Client/Injuries/InjuryReport.lua
@@ -120,10 +120,7 @@ local function AddMultiplierRows(reportTable, entity, injuryConfig, totalAmount,
 	if npcCategory then
 		local npcMulti = reportTable:AddRow()
 		local npcDisplay = npcMulti:AddCell()
-		npcDisplay:AddText(Translator:translate("NPC Category"))
-		local seeNpcButton = npcDisplay:AddImageButton("npcCategory", "Spell_Divination_SeeInvisibility", { 30, 30 })
-		seeNpcButton.SameLine = true
-		seeNpcButton:Tooltip():AddText("\t" .. npcCategory)
+		npcDisplay:AddText(Translator:translate("NPC Category") .. string.format(" - %s", npcCategory))
 
 		npcMulti:AddCell():AddText(string.format("%s%%", characterMultiplier * 100))
 		npcMulti:AddCell():AddText("---")
@@ -143,13 +140,14 @@ local function CreateReport(group)
 	reportButton:Tooltip():AddText("\tClick To Toggle")
 
 	local reportTable = group:AddTable(group.UserData .. "Report", 4)
+	-- reportTable:AddColumn("First", "WidthFixed")
 	reportTable.SizingStretchSame = true
 	reportTable.BordersInnerH = true
 	reportTable.Visible = false
 
 	local statusReportHeaders = reportTable:AddRow()
 	statusReportHeaders.Headers = true
-	statusReportHeaders:AddCell():AddText("")
+	statusReportHeaders:AddCell():AddText(" ")
 	statusReportHeaders:AddCell():AddText(Translator:translate("Multiplier"))
 	statusReportHeaders:AddCell():AddText(Translator:translate("Before"))
 	statusReportHeaders:AddCell():AddText(Translator:translate("After"))
@@ -216,8 +214,6 @@ local function BuildReport()
 				BuildReport()
 			end
 
-			local characterMultiplier, npcCategory = InjuryCommonLogic:CalculateNpcMultiplier(entity)
-
 			local keepHeader = false
 
 			for injury, injuryConfig in TableUtils:OrderedPairs(ConfigurationStructure.config.injuries.injury_specific, function(key)
@@ -225,6 +221,8 @@ local function BuildReport()
 				local status = Ext.Stats.Get(key)
 				return status and Ext.Loca.GetTranslatedString(status.DisplayName, key) or key
 			end) do
+				local characterMultiplier, npcCategory = InjuryCommonLogic:CalculateNpcMultiplier(entity, injury)
+
 				---@cast injuryConfig Injury
 
 				---@type StatusData?

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Client/Injuries/Tabs/CharacterMultipliers.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Client/Injuries/Tabs/CharacterMultipliers.lua
@@ -173,6 +173,74 @@ InjuryMenu:RegisterTab(function(tabBar, injury)
 		end
 	end
 	--#endregion
+
+	--#region NPC Multipliers
+	multiplierTab:AddNewLine()
+	local npcHeader = multiplierTab:AddCollapsingHeader(Translator:translate("Damage + Status Multipliers For NPCs"))
+
+	local enemyDesc = npcHeader:AddText(
+		Translator:translate(
+			"These % multipliers will apply after the ones set per-injury (0 = no Injury damage will be taken) - NPC-type determinations are made by their associated Experience Reward Category. These will override the ones set in the universal 'Applying Injuries' settings."
+			.. " Supports Mod-added XPReward categories as long as they use the same names prepended with `_` - e.g. MMM_Combatant"))
+	enemyDesc.TextWrapPos = 0
+	enemyDesc:SetStyle("Alpha", 0.65)
+
+	local enemyMultTable = npcHeader:AddTable("Injury Specific Enemy Multiplier Table", 2)
+	enemyMultTable.SizingStretchProp = true
+
+	local function buildNpcMultiSlider(npcType)
+		local newRow = enemyMultTable:AddRow()
+		newRow:AddCell():AddText(npcType)
+
+		if not charMultiplierConfig["npc_multipliers"] then
+			charMultiplierConfig["npc_multipliers"] = {}
+		end
+
+		if not charMultiplierConfig["npc_multipliers"][npcType] then
+			charMultiplierConfig["npc_multipliers"][npcType] = 1
+		end
+
+		local newSlider = newRow:AddCell():AddSliderInt("", math.floor(charMultiplierConfig["npc_multipliers"][npcType] * 100), 0, 500)
+		newSlider.OnChange = function(slider)
+			---@cast slider ExtuiSliderInt
+			charMultiplierConfig["npc_multipliers"][npcType] = slider.Value[1] / 100
+		end
+
+		return newRow
+	end
+
+	local addNPCRowButton = npcHeader:AddButton("+")
+	addNPCRowButton.IDContext = "injury_specific" .. addNPCRowButton.Label
+	local npcPopop = multiplierTab:AddPopup("Injury Specific NPC Multiplier")
+	local npcTypes = { "Boss", "MiniBoss", "Elite", "Combatant", "Pack", "Zero", "Civilian" }
+
+	for i, npcType in pairs(npcTypes) do
+		---@type ExtuiSelectable
+		local enemySelect = npcPopop:AddSelectable(npcType, "DontClosePopups")
+		enemySelect.IDContext = "injury_specific" .. enemySelect.Label
+
+		enemySelect.OnActivate = function()
+			if enemySelect.UserData then
+				enemySelect.UserData:Destroy()
+				enemySelect.UserData = nil
+				charMultiplierConfig["npc_multipliers"][npcType] = nil
+			else
+				enemySelect.UserData = buildNpcMultiSlider(npcType)
+			end
+		end
+
+		if charMultiplierConfig["npc_multipliers"] and charMultiplierConfig["npc_multipliers"][npcType] then
+			enemySelect.Selected = true
+			enemySelect:OnActivate()
+		end
+	end
+
+	addNPCRowButton.OnClick = function()
+		npcPopop:Open()
+	end
+
+	multiplierTab:AddNewLine()
+	--#endregion
 end)
 
 Translator:RegisterTranslation({
@@ -195,8 +263,7 @@ Translator:RegisterTranslation({
 	["Tag UUID:"] = "h72738de2d12d41798d6780e4512bef70a9g1",
 	["Display Description:"] = "h56eb6fe545af4fe3b335bc5483844b98be02",
 	["Delete"] = "h55fb845d61da4b6ba21457c35b05edfc672g",
-	[""] = "",
-	[""] = "",
-	[""] = "",
-	[""] = "",
+	["Damage + Status Multipliers For NPCs"] = "hfb5b81035983400b974aa2f4aec01a1e369b",
+	["These % multipliers will apply after the ones set per-injury (0 = no Injury damage will be taken) - NPC-type determinations are made by their associated Experience Reward Category. These will override the ones set in the universal 'Applying Injuries' settings."
+	.. " Supports Mod-added XPReward categories as long as they use the same names prepended with `_` - e.g. MMM_Combatant"] = "hf711296ce96b4c9e8dd776fda7c9755680b0",
 })

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Server/Injuries/_ApplyOnStatus.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Server/Injuries/_ApplyOnStatus.lua
@@ -8,8 +8,6 @@ local function processInjuries(entity, status, statusConfig, injuryVar, statusGr
 	local statusVar = injuryVar["applyOnStatus"]
 	local character = entity.Uuid.EntityUuid
 
-	local npcMultiplier = InjuryCommonLogic:CalculateNpcMultiplier(entity)
-
 	---@type {string: InjuryName[]}
 	local appliedInjuriesTracker = {}
 
@@ -24,6 +22,8 @@ local function processInjuries(entity, status, statusConfig, injuryVar, statusGr
 		local nextStackInjury = InjuryCommonLogic:GetNextInjuryInStackIfApplicable(character, injury)
 		Logger:BasicDebug("Status %s will apply %s (possibly upgraded from %s) to %s", status, nextStackInjury, injury, character)
 		if nextStackInjury and Osi.HasActiveStatus(character, nextStackInjury) == 0 then
+			local npcMultiplier = InjuryCommonLogic:CalculateNpcMultiplier(entity, nextStackInjury)
+
 			if statusGroup and statusData.StatusGroups and TableUtils:ListContains(statusData.StatusGroups, statusGroup) then
 				if injuryStatusConfig["excluded_statuses"] and TableUtils:ListContains(injuryStatusConfig["excluded_statuses"], status) then
 					Logger:BasicDebug("%s belongs to status group %s but is excluded, so skipping", nextStackInjury, statusGroup)

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Server/Injuries/_Damage.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Server/Injuries/_Damage.lua
@@ -37,8 +37,6 @@ local function ProcessDamageEvent(event)
 
 	RandomInjuryOnConditionProcessor:ProcessDamageEvent(event, defender, tempHpReductionTable)
 
-	local npcMultiplier = InjuryCommonLogic:CalculateNpcMultiplier(defenderEntity)
-
 	---@type InjuryApplicationChanceModifiers[]
 	local modifiers = {}
 	for _, statsRoll in pairs(event.Hit.Damage.DamageRolls) do
@@ -75,6 +73,8 @@ local function ProcessDamageEvent(event)
 						and Osi.HasActiveStatus(defender, nextStackInjury) == 0
 						and not injuryVar["injuryAppliedReason"][nextStackInjury]
 					then
+						local npcMultiplier = InjuryCommonLogic:CalculateNpcMultiplier(defenderEntity, nextStackInjury)
+
 						local finalDamageWithPreviousDamage = finalDamageAmount
 
 						if injury ~= nextStackInjury then

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Server/_ConfigManager.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Server/_ConfigManager.lua
@@ -1,5 +1,6 @@
 ConfigManager = {}
 
+---@type Configuration
 ConfigManager.ConfigCopy = {}
 
 -- Need to make sure the server's copy of the config is up-to-date since that's where the actual functionality is

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Shared/Injuries/_InjuryCommonLogic.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Shared/Injuries/_InjuryCommonLogic.lua
@@ -115,7 +115,7 @@ if Ext.IsServer() then
 		if not ConfigManager.ConfigCopy.injuries then
 			return false
 		end
-		
+
 		if Osi.IsItem(character) == 1
 			or Osi.Exists(character) == 0
 			or Osi.IsDead(character) == 1

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Shared/Injuries/_InjuryCommonLogic.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Shared/Injuries/_InjuryCommonLogic.lua
@@ -35,8 +35,9 @@ InjuryCommonLogic = {}
 --- Returns the npcType just for the InjuryReport, so we know if the character even has a multiplier available instead of
 --- defaulting in the absence of one
 ---@param character EntityHandle
+---@param injuryName InjuryName?
 ---@return number, string?
-function InjuryCommonLogic:CalculateNpcMultiplier(character)
+function InjuryCommonLogic:CalculateNpcMultiplier(character, injuryName)
 	if not character or not character.Data then
 		return 1
 	end
@@ -53,19 +54,35 @@ function InjuryCommonLogic:CalculateNpcMultiplier(character)
 		else
 			config = ConfigurationStructure.config
 		end
-		config = config.injuries.universal
 
-		local lowerCat = string.lower(xpCategory)
-		for npcType, multiplier in pairs(config.npc_multipliers) do
-			npcType = string.lower(npcType)
+		local function determineMultiplier(localconfig)
+			local lowerCat = string.lower(xpCategory)
+			for npcType, multiplier in pairs(localconfig.npc_multipliers) do
+				npcType = string.lower(npcType)
 
-			-- Some mods use custom categories, like MMM using MMM_{type}, so need to try to account for those. Hopefully they all use `_`
-			if lowerCat == npcType or string.find(lowerCat, "_" .. npcType .. "$") then
-				return multiplier, xpCategory
+				-- Some mods use custom categories, like MMM using MMM_{type}, so need to try to account for those. Hopefully they all use `_`
+				if lowerCat == npcType or string.find(lowerCat, "_" .. npcType .. "$") then
+					return multiplier
+				end
 			end
 		end
 
-		return config.npc_multipliers["Base"], xpCategory .. " (Base Multiplier)"
+		if injuryName
+			and config.injuries.injury_specific[injuryName].character_multipliers
+			and config.injuries.injury_specific[injuryName].character_multipliers["npc_multipliers"]
+		then
+			local multiplier = determineMultiplier(config.injuries.injury_specific[injuryName].character_multipliers)
+			if multiplier then
+				return multiplier, xpCategory .. " (Injury Override)"
+			end
+		end
+
+		local multiplier = determineMultiplier(config.injuries.universal)
+		if multiplier then
+			return multiplier, xpCategory
+		end
+
+		return config.injuries.universal.npc_multipliers["Base"], xpCategory .. " (Base Multiplier)"
 	end
 end
 

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Shared/Injuries/_InjuryCommonLogic.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Shared/Injuries/_InjuryCommonLogic.lua
@@ -112,6 +112,10 @@ if Ext.IsServer() then
 	---@param character GUIDSTRING
 	---@return boolean
 	function InjuryCommonLogic:IsEligible(character)
+		if not ConfigManager.ConfigCopy.injuries then
+			return false
+		end
+		
 		if Osi.IsItem(character) == 1
 			or Osi.Exists(character) == 0
 			or Osi.IsDead(character) == 1

--- a/Injuries/Mods/Injuries/ScriptExtender/Lua/Shared/Injuries/_InjuryConfig.lua
+++ b/Injuries/Mods/Injuries/ScriptExtender/Lua/Shared/Injuries/_InjuryConfig.lua
@@ -163,7 +163,9 @@ ConfigurationStructure.DynamicClassDefinitions.injury_class.character_multiplier
 	---@type {[TAG] : number}?
 	["tags"] = nil,
 	---@type {[GUIDSTRING] : number}?
-	["races"] = nil
+	["races"] = nil,
+	---@type { [NPCCategories] : number}?
+	["npc_multipliers"] = nil
 }
 
 ---@alias InjuryName string


### PR DESCRIPTION
Also adds a safeguard against statuses being applied before the config loads (e.g. by CX)